### PR TITLE
feat(docs): add man subcommand to gen man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 .envrc
 dist/
 orchid/orchid
+
+# generated man pages
+*.1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,8 +11,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
-      - darwin
     goarch:
       - amd64
       - arm64

--- a/cmdr/app.go
+++ b/cmdr/app.go
@@ -30,6 +30,11 @@ func NewApp(name string) *App {
 
 func (a *App) CreateRootCommand(c *Command) {
 	a.RootCommand = c
+	manCmd := NewManCommand(a.Name)
+	manC := &Command{
+		Command: manCmd,
+	}
+	a.RootCommand.AddCommand(manC)
 }
 
 func (a *App) Run() error {

--- a/cmdr/man.go
+++ b/cmdr/man.go
@@ -1,0 +1,43 @@
+package cmdr
+
+/*	License: GPLv3
+	Authors:
+		Mirko Brombin <send@mirko.pm>
+		Pietro di Caprio <pietro@fabricators.ltd>
+	Copyright: 2023
+	Description: Orchid is a cli helper for VanillaOS projects
+*/
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func NewManCommand(title string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "man",
+		Short:                 "Generates manpages",
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+		Hidden:                true,
+		Args:                  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			/*		manPage, err := mcoral.NewManPage(1, cmd.Root())
+					if err != nil {
+						return err
+					}
+
+					_, err = fmt.Fprint(os.Stdout, manPage.Build(roff.NewDocument()))
+					return err
+			*/
+			header := &doc.GenManHeader{
+				Title:   title,
+				Source:  "VanillaOS/orchid man page generator",
+				Section: "1",
+			}
+			return doc.GenManTree(cmd.Root(), header, "manpages")
+
+		},
+	}
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	atomicgo.dev/cursor v0.1.1 // indirect
 	atomicgo.dev/keyboard v0.2.8 // indirect
 	github.com/containerd/console v1.0.3 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gookit/color v1.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -23,6 +24,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -189,6 +190,7 @@ github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/orchid/main.go
+++ b/orchid/main.go
@@ -5,15 +5,15 @@ import (
 )
 
 func main() {
-	bean := cmdr.NewApp("orchid")
+	oapp := cmdr.NewApp("orchid")
 	// this is output to the user
 
 	// root command
 	root := cmdr.NewCommand("orchid <options>", "orchid is a cli helper for VanillaOS projects", "orchid is a cli helper for VanillaOS projects", nil)
-	bean.CreateRootCommand(root)
+	oapp.CreateRootCommand(root)
 
 	// run the app
-	err := bean.Run()
+	err := oapp.Run()
 	if err != nil {
 		cmdr.Error.Println(err)
 


### PR DESCRIPTION
If merged this PR adds a `man` subcommand to any cli tool that uses orchid. It generates man pages in a `manpages` directory in the root of the repo. It will fail if that directory doesn't exist.