### PR TITLE
feat: generate markdown documentation

### DIFF
--- a/cmdr/app.go
+++ b/cmdr/app.go
@@ -84,6 +84,9 @@ func (a *App) CreateRootCommand(c *Command) {
 	c.DisableAutoGenTag = true
 	manCmd := NewManCommand(a)
 	a.RootCommand.AddCommand(manCmd)
+
+	docsCmd := NewDocsCommand(a)
+	a.RootCommand.AddCommand(docsCmd)
 }
 
 func (a *App) Run() error {

--- a/cmdr/docs.go
+++ b/cmdr/docs.go
@@ -1,0 +1,65 @@
+package cmdr
+
+/*	License: GPLv3
+	Authors:
+		Mirko Brombin <send@mirko.pm>
+		Pietro di Caprio <pietro@fabricators.ltd>
+	Copyright: 2023
+	Description: Orchid is a cli helper for VanillaOS projects
+*/
+
+import (
+	"fmt"
+	"log"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func NewDocsCommand(a *App) *Command {
+	c := &Command{}
+	cmd := &cobra.Command{
+		Use:                   "docs",
+		Short:                 "Generates documentation for the cli application in the current directory.",
+		SilenceUsage:          true,
+		DisableFlagsInUseLine: true,
+		Hidden:                true,
+		Args:                  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			filePrepender := func(filename string) string {
+				name := filepath.Base(filename)
+				base := strings.TrimSuffix(name, path.Ext(name))
+				return fmt.Sprintf(fmTemplate, strings.Replace(base, "_", " ", -1), strings.Replace(base, "_", " ", -1))
+			}
+			linkHandler := func(name string) string {
+				base := strings.TrimSuffix(name, path.Ext(name))
+				return strings.ToLower(base) + "/"
+			}
+			/*	err := doc.GenMarkdownTree(cmd.Root(), "./")
+				if err != nil {
+					log.Fatal(err)
+				}
+			*/
+			err := doc.GenMarkdownTreeCustom(cmd.Root(), "./", filePrepender, linkHandler)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+			return nil
+
+		},
+	}
+	c.Command = cmd
+	return c
+
+}
+
+const fmTemplate = `---
+title: "%s"
+description: %s
+
+---
+`

--- a/example/bean.md
+++ b/example/bean.md
@@ -1,0 +1,26 @@
+---
+title: "bean"
+description: bean
+
+---
+## bean
+
+bean manages pods
+
+### Synopsis
+
+bean is a tool for managing your vanilla pods
+
+### Options
+
+```
+  -d, --doit   do the thing
+  -h, --help   help for bean
+```
+
+### SEE ALSO
+
+* [bean completion](bean_completion/)	 - Generate the autocompletion script for the specified shell
+* [bean do](bean_do/)	 - do things with beans
+* [bean roast](bean_roast/)	 - roast warms up your beans
+

--- a/example/bean_completion.md
+++ b/example/bean_completion.md
@@ -1,0 +1,35 @@
+---
+title: "bean completion"
+description: bean completion
+
+---
+## bean completion
+
+Generate the autocompletion script for the specified shell
+
+### Synopsis
+
+Generate the autocompletion script for bean for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --doit   do the thing
+```
+
+### SEE ALSO
+
+* [bean](bean/)	 - bean manages pods
+* [bean completion bash](bean_completion_bash/)	 - Generate the autocompletion script for bash
+* [bean completion fish](bean_completion_fish/)	 - Generate the autocompletion script for fish
+* [bean completion powershell](bean_completion_powershell/)	 - Generate the autocompletion script for powershell
+* [bean completion zsh](bean_completion_zsh/)	 - Generate the autocompletion script for zsh
+

--- a/example/bean_completion_bash.md
+++ b/example/bean_completion_bash.md
@@ -1,0 +1,54 @@
+---
+title: "bean completion bash"
+description: bean completion bash
+
+---
+## bean completion bash
+
+Generate the autocompletion script for bash
+
+### Synopsis
+
+Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+	source <(bean completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	bean completion bash > /etc/bash_completion.d/bean
+
+#### macOS:
+
+	bean completion bash > $(brew --prefix)/etc/bash_completion.d/bean
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+bean completion bash
+```
+
+### Options
+
+```
+  -h, --help              help for bash
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --doit   do the thing
+```
+
+### SEE ALSO
+
+* [bean completion](bean_completion/)	 - Generate the autocompletion script for the specified shell
+

--- a/example/bean_completion_fish.md
+++ b/example/bean_completion_fish.md
@@ -1,0 +1,45 @@
+---
+title: "bean completion fish"
+description: bean completion fish
+
+---
+## bean completion fish
+
+Generate the autocompletion script for fish
+
+### Synopsis
+
+Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+	bean completion fish | source
+
+To load completions for every new session, execute once:
+
+	bean completion fish > ~/.config/fish/completions/bean.fish
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+bean completion fish [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for fish
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --doit   do the thing
+```
+
+### SEE ALSO
+
+* [bean completion](bean_completion/)	 - Generate the autocompletion script for the specified shell
+

--- a/example/bean_completion_powershell.md
+++ b/example/bean_completion_powershell.md
@@ -1,0 +1,42 @@
+---
+title: "bean completion powershell"
+description: bean completion powershell
+
+---
+## bean completion powershell
+
+Generate the autocompletion script for powershell
+
+### Synopsis
+
+Generate the autocompletion script for powershell.
+
+To load completions in your current shell session:
+
+	bean completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+
+```
+bean completion powershell [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for powershell
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --doit   do the thing
+```
+
+### SEE ALSO
+
+* [bean completion](bean_completion/)	 - Generate the autocompletion script for the specified shell
+

--- a/example/bean_completion_zsh.md
+++ b/example/bean_completion_zsh.md
@@ -1,0 +1,56 @@
+---
+title: "bean completion zsh"
+description: bean completion zsh
+
+---
+## bean completion zsh
+
+Generate the autocompletion script for zsh
+
+### Synopsis
+
+Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+	echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load completions in your current shell session:
+
+	source <(bean completion zsh); compdef _bean bean
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	bean completion zsh > "${fpath[1]}/_bean"
+
+#### macOS:
+
+	bean completion zsh > $(brew --prefix)/share/zsh/site-functions/_bean
+
+You will need to start a new shell for this setup to take effect.
+
+
+```
+bean completion zsh [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for zsh
+      --no-descriptions   disable completion descriptions
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --doit   do the thing
+```
+
+### SEE ALSO
+
+* [bean completion](bean_completion/)	 - Generate the autocompletion script for the specified shell
+

--- a/example/bean_do.md
+++ b/example/bean_do.md
@@ -1,0 +1,42 @@
+---
+title: "bean do"
+description: bean do
+
+---
+## bean do
+
+do things with beans
+
+### Synopsis
+
+do has a longer description that spans several lines and has some line breaks and other interesting things.
+This is a second paragraph and it will be obvious that there is a line break.
+
+
+```
+bean do [flags]
+```
+
+### Examples
+
+```
+bean do -r
+```
+
+### Options
+
+```
+  -h, --help     help for do
+  -r, --really   really do it
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --doit   do the thing
+```
+
+### SEE ALSO
+
+* [bean](bean/)	 - bean manages pods
+

--- a/example/bean_roast.md
+++ b/example/bean_roast.md
@@ -1,0 +1,40 @@
+---
+title: "bean roast"
+description: bean roast
+
+---
+## bean roast
+
+roast warms up your beans
+
+### Synopsis
+
+roast has a longer description that spans several lines and has some line breaks and other interesting things.
+
+```
+bean roast [flags]
+```
+
+### Examples
+
+```
+bean roast -n arabica
+```
+
+### Options
+
+```
+  -h, --help          help for roast
+  -n, --name string   name of the bean (default "defaultedBean")
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --doit   do the thing
+```
+
+### SEE ALSO
+
+* [bean](bean/)	 - bean manages pods
+

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	atomicgo.dev/cursor v0.1.1 // indirect
 	atomicgo.dev/keyboard v0.2.8 // indirect
 	github.com/containerd/console v1.0.3 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gookit/color v1.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -24,6 +25,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -191,6 +192,7 @@ github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=


### PR DESCRIPTION
If this patch is merged, all commands using `orchid` will get a new `docs` subcommand that is hidden by default. The docs command will generate a markdown file for each command in the current working directory.

example:
`cd webdocs && abroot docs`