### PR TITLE
feat/ci: update workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     tags:
       - 'v*'
   pull_request:
@@ -15,13 +15,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.21
           cache: true
       - run: go mod tidy
       - run: go test -v ./...
-      - uses: goreleaser/goreleaser-action@v4
+      - uses: goreleaser/goreleaser-action@v5
         if: success() && startsWith(github.ref, 'refs/tags/')
         with:
           version: latest


### PR DESCRIPTION
## Changes

- Bump `actions/setup-go` to `v5` (Node 20).
- Fix the workflow branch and set it to main.
- Bump `goreleaser/goreleaser-action` to `v5`.
- Set the `go` version to 1.21.